### PR TITLE
Laravel 4.2 Compatible Tracer

### DIFF
--- a/src/Providers/QueryTracerServiceProvider.php
+++ b/src/Providers/QueryTracerServiceProvider.php
@@ -13,9 +13,11 @@ class QueryTracerServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot(DispatcherContract $events)
+    public function boot()
     {
-        $events->listen('eloquent.booted: *', function ($model) {
+        $app = $this->app;
+
+        $app->events->listen('eloquent.booted: *', function ($model) {
             $model->addGlobalScope(new QueryTracer);
         });
     }

--- a/src/Scopes/QueryTracer.php
+++ b/src/Scopes/QueryTracer.php
@@ -3,24 +3,21 @@
 namespace Fitztrev\QueryTracer\Scopes;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Database\Eloquent\ScopeInterface;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Config;
 
-class QueryTracer implements Scope
+class QueryTracer implements ScopeInterface
 {
 
-    private function isEnabled(Model $model)
+    private function isEnabled()
     {
-        if (method_exists($model, 'enableQueryTracer')) {
-            return $model->enableQueryTracer();
-        }
-
-        return config('app.debug');
+        return Config::get('app.debug');
     }
 
-    public function apply(Builder $builder, Model $model)
+    public function apply(Builder $builder)
     {
-        if (! $this->isEnabled($model)) {
+        if (! $this->isEnabled()) {
             return;
         }
 
@@ -36,4 +33,9 @@ class QueryTracer implements Scope
             }
         }
     }
+
+    public function remove(Builder $builder) {
+        return $builder;
+    }
+
 }

--- a/src/Scopes/QueryTracer.php
+++ b/src/Scopes/QueryTracer.php
@@ -35,7 +35,7 @@ class QueryTracer implements ScopeInterface
     }
 
     public function remove(Builder $builder) {
-        return $builder;
+
     }
 
 }


### PR DESCRIPTION
Hi Trevor,

just dropin it here if someone wants to use it under the Laravel 4.2 version.

`composer.json` example:

```
{
    ...
    "repositories": [
      {
        "type": "vcs",
        "url": "https://github.com/cossou/query-tracer"
      }
    ],
    "require": {
        "laravel/framework": "4.2.*",
        "barryvdh/laravel-debugbar": "1.*",
        "fitztrev/query-tracer": "dev-master"
    },
}
```

PS: No tests, no warranty. 😄 
